### PR TITLE
feat: add accessibility for datetime on booking-item component

### DIFF
--- a/app/_components/booking-item.tsx
+++ b/app/_components/booking-item.tsx
@@ -82,7 +82,13 @@ const BookingItem = ({ booking }: BookingItemProps) => {
                 })}
               </p>
               <p className="text-2xl">{format(booking.date, "dd")}</p>
-              <p className="text-sm">{format(booking.date, "hh:mm")}</p>
+              <time 
+                className="text-sm"
+                title={format(booking.date, "dd 'de' MMMM 'ás' hh:mm", { locale: ptBR})} 
+                dateTime={booking.date.toISOString()}
+              >
+                {format(booking.date, "hh:mm")}
+              </time>
             </div>
           </CardContent>
         </Card>
@@ -141,7 +147,13 @@ const BookingItem = ({ booking }: BookingItemProps) => {
 
               <div className="flex justify-between">
                 <h3 className="text-gray-400 text-sm">Horário</h3>
-                <h4 className="text-sm">{format(booking.date, "hh:mm")}</h4>
+                <time 
+                  className="text-sm"
+                  title={format(booking.date, "dd 'de' MMMM 'ás' hh:mm", { locale: ptBR})} 
+                  dateTime={booking.date.toISOString()}
+                >
+                  {format(booking.date, "hh:mm")}
+                </time>
               </div>
 
               <div className="flex justify-between">


### PR DESCRIPTION
Thinking about screen readers. added accessibility for date and time in booking item component.